### PR TITLE
ユーザー詳細ページで投稿削除できないエラーを修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,7 +77,7 @@
             <td>
               <%= link_to "詳細", post_path(post.id), class: "btn btn-success" %>
               <% if post.user_id == current_user.id %>
-                <%= link_to "削除", post_path, method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
+                <%= link_to "削除", post_path(post.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
               <% end %>
             </td>
           </tr>

--- a/spec/requests/homes_spec.rb
+++ b/spec/requests/homes_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe "Homes", type: :request do
   describe "トップページのテスト" do
-
     before do
       get root_path
     end


### PR DESCRIPTION
post_pathにpostのidが入っていなかったため修正