### PR TITLE
herokuのみPostgreSQLを使用するように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '3.2.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.7', '>= 6.1.7.3'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+gem 'sqlite3', '~> 1.4', group: :development
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
@@ -61,3 +61,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'rails-i18n'
 gem 'devise'
 gem 'google-api-client', '~> 0.11'
+gem 'pg', group: :production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   google-api-client (~> 0.11)
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  pg
   pry-rails
   puma (~> 5.0)
   rails (~> 6.1.7, >= 6.1.7.3)

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,6 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  pool: 5


### PR DESCRIPTION
herokuではPostgreSQLを使用しているので統一するため。
アプリ作成後にSQLite3だとエラーになる可能性があると判明したので、
herokuのみPostgreSQLを使用するように変更。